### PR TITLE
Fix indexing dictionary.values

### DIFF
--- a/n88tools/faim.py
+++ b/n88tools/faim.py
@@ -155,9 +155,9 @@ Select and run solver manually.""")
         # The test for a material array is if there are any variables defined.
         if (not has_elastoplastic and
             len(materials) == 1 and
-            len(materials[0].variables) > 0):
+            len(list(materials)[0].variables) > 0):
             # Compare length of first variable of first material to number_elements
-            if (materials[0].variables.values()[0].shape[0] == number_elements):
+            if (list(list(materials)[0].variables.values())[0].shape[0] == number_elements):
                 has_max_length_material_array = True
         rootGroup.close()
 

--- a/n88tools/postfaim.py
+++ b/n88tools/postfaim.py
@@ -137,7 +137,7 @@ def postfaim():
         material = materialDefinitions.groups[materialNames[m]]
         if len(material.variables) != 0:
             # Has at least one netcdf variable -> is a material array
-            materialArrayLength[m] = material.variables.values()[0].shape[0]
+            materialArrayLength[m] = list(material.variables.values())[0].shape[0]
 
     def SplitOnCommaOrSemicolon (s):
         tokens = s.split(",")


### PR DESCRIPTION
@nik-knowles 
FYI @stevenkboyd 

Issue:
- Python 2 supported numerical indexing of dict.values, Python 3 does not.
- Fixed all occurrences found by searching for `.values`

Solution:
- Wrap all indexes with `list(.)` to allow indexing. Since the dictionary indexing is so intimately linked to the material properties, I do not see a cleaner solution.

See https://stackoverflow.com/questions/17431638/get-typeerror-dict-values-object-does-not-support-indexing-when-using-python

Closes https://github.com/Numerics88/n88tools/issues/4